### PR TITLE
Handle corrupted SQLite DB

### DIFF
--- a/app.py
+++ b/app.py
@@ -4,6 +4,9 @@ import os
 import logging
 import streamlit as st
 
+logging.basicConfig(level=logging.INFO)
+logger = logging.getLogger(__name__)
+
 # נסה לייבא את מנוע החיפוש
 try:
     # Alias for clarity with the cached loader below
@@ -12,9 +15,9 @@ try:
     # Use Streamlit caching so the engine is constructed only once per session
     @st.cache_resource
     def get_search_engine():
-        print("Attempting to load search engine...")
+        logger.info("Attempting to load search engine...")
         engine = SearchEngine()
-        print("Search engine loaded successfully!")
+        logger.info("Search engine loaded successfully!")
         return engine
 
     # Load the search engine using the cached function
@@ -22,7 +25,7 @@ try:
 
     SEARCH_AVAILABLE = True
 except Exception as e:
-    print(f"⚠️  מנוע חיפוש לא זמין: {e}")
+    logger.exception(f"Search engine unavailable: {e}")
     SEARCH_AVAILABLE = False
     search_engine = None
 

--- a/semantic_search.py
+++ b/semantic_search.py
@@ -60,7 +60,10 @@ class AIToolsSemanticSearch:
                 self.tools_data.append(tool)
             
             conn.close()
-            
+
+        except sqlite3.DatabaseError as e:
+            logger.error(f"Database error loading data: {e}")
+            raise
         except Exception as e:
             logger.error(f"שגיאה בטעינת נתונים: {e}")
             # ניסיון עם נתונים דמה אם מסד הנתונים לא זמין

--- a/tests/test_semantic_search.py
+++ b/tests/test_semantic_search.py
@@ -15,10 +15,19 @@ def load_semantic_search(monkeypatch):
     # Ensure project root on path
     root = os.path.dirname(os.path.dirname(__file__))
     sys.path.insert(0, root)
-    # Stub out heavy dependency
+    # Stub out heavy dependencies
     dummy_module = types.ModuleType('sentence_transformers')
     dummy_module.SentenceTransformer = lambda *args, **kwargs: DummyModel()
     monkeypatch.setitem(sys.modules, 'sentence_transformers', dummy_module)
+    sklearn_root = types.ModuleType('sklearn')
+    sklearn_metrics = types.ModuleType('sklearn.metrics')
+    sklearn_pairwise = types.ModuleType('sklearn.metrics.pairwise')
+    sklearn_pairwise.cosine_similarity = lambda a, b: [[0.0 for _ in range(len(b))] for _ in range(len(a))]
+    sklearn_metrics.pairwise = sklearn_pairwise
+    sklearn_root.metrics = sklearn_metrics
+    monkeypatch.setitem(sys.modules, 'sklearn', sklearn_root)
+    monkeypatch.setitem(sys.modules, 'sklearn.metrics', sklearn_metrics)
+    monkeypatch.setitem(sys.modules, 'sklearn.metrics.pairwise', sklearn_pairwise)
     if 'semantic_search' in sys.modules:
         del sys.modules['semantic_search']
     module = importlib.import_module('semantic_search')
@@ -45,3 +54,15 @@ def test_get_random_tools_returns_copies(monkeypatch):
         assert ret is not original
     results[0]['name'] = 'Changed'
     assert engine.tools_data[0]['name'] == 'Tool1'
+
+
+def test_corrupted_database_raises(monkeypatch):
+    sem = load_semantic_search(monkeypatch)
+
+    def bad_connect(*args, **kwargs):
+        raise sem.sqlite3.DatabaseError("database disk image is malformed")
+
+    monkeypatch.setattr(sem.sqlite3, 'connect', bad_connect)
+
+    with pytest.raises(sem.sqlite3.DatabaseError):
+        sem.AIToolsSemanticSearch(db_path='corrupt.db')


### PR DESCRIPTION
## Summary
- detect SQLite corruption errors while loading the database
- log search engine initialization via logging
- add test that corrupted DB propagates an exception
- stub sklearn in tests

## Testing
- `pytest -q`

------
https://chatgpt.com/codex/tasks/task_e_687fd63d60e083328b3b634474e59277